### PR TITLE
Strip whitespace from domains

### DIFF
--- a/lib/email-addresses.js
+++ b/lib/email-addresses.js
@@ -601,6 +601,10 @@ function parse5322(opts) {
                     return null;
                 }
             }
+            // strip all whitespace from domains
+            if (result) {
+                result.semantic = result.semantic.replace(/\s+/g, '');
+            }
             return result;
         }());
     }
@@ -821,7 +825,7 @@ function parse5322(opts) {
                     name: name,
                     address: aspec,
                     local: local,
-                    domain: domain
+                    domain: domain,
                 },
                 name: grabSemantic(name),
                 address: grabSemantic(aspec),

--- a/test/email-addresses.js
+++ b/test/email-addresses.js
@@ -270,3 +270,14 @@ test("dots in unquoted display-names", function (t) {
 
     t.end();
 });
+
+test("whitespace in domain", function (t) {
+    var fxn, result;
+    fxn = addrs.parseOneAddress;
+
+    result = fxn('":sysmail"@ Some-Group. Some-Org');
+    t.ok(result, "spaces in domain parses ok");
+    t.equal(result.domain, 'Some-Group.Some-Org', "domain parsing strips whitespace");
+    
+    t.end();
+})


### PR DESCRIPTION
This change turns (obs) domains with whitespace in them into a usable domain.