### PR TITLE
Don't use per-char tests for collapse ws

### DIFF
--- a/lib/email-addresses.js
+++ b/lib/email-addresses.js
@@ -186,27 +186,7 @@ function parse5322(opts) {
     // "First Last" -> "First Last"
     // "First   Last" -> "First Last"
     function collapseWhitespace(s) {
-        function isWhitespace(c) {
-            return c === ' ' ||
-                   c === '\t' ||
-                   c === '\r' ||
-                   c === '\n';
-        }
-        var i, str;
-        str = "";
-        for (i = 0; i < s.length; i += 1) {
-            if (!isWhitespace(s[i]) || !isWhitespace(s[i + 1])) {
-                str += s[i];
-            }
-        }
-
-        if (isWhitespace(str[0])) {
-            str = str.substring(1);
-        }
-        if (isWhitespace(str[str.length - 1])) {
-            str = str.substring(0, str.length - 1);
-        }
-        return str;
+        return s.replace(/([ \t]|\r\n)+/g, ' ').replace(/^\s*/, '').replace(/\s*$/, '');
     }
 
     // UTF-8 pseudo-production (RFC 6532)


### PR DESCRIPTION
This change greatly simplifies the collapesWhitespace function.