### PR TITLE
Fix Typescript typings reference in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,5 @@
     "test": "tap ./test"
   },
   "license": "MIT",
-  "typescript": {
-    "definition": "./lib/email-addresses.d.ts"
-  }
+  "typings": "./lib/email-addresses.d.ts"
 }


### PR DESCRIPTION
In package.json, Typescript uses the `typings` field for typings inclusion to parallel the `main` field. Types will not import in projects with `"moduleResolution": "node"` in their tsconfig.json without this being set properly. ("Classic" resolution will find the typings sitting next to the code automatically.) The Typescript handbook page for "Module Resolution" has had this since it was created: https://github.com/Microsoft/TypeScript-Handbook/commit/ebcc381f5484ca1e30409a8d63c596b3319ad629#diff-25c8beea244b6bab4b70c89e290fdb4e